### PR TITLE
#44 fixed problem autofilling phone fild when editing at admin/employees

### DIFF
--- a/app/Http/Livewire/Admins/Employees.php
+++ b/app/Http/Livewire/Admins/Employees.php
@@ -70,7 +70,6 @@ class Employees extends Component
     {
         $employee = employee::findOrFail($id);
         $this->edit_employee_id = $id;
-
         $this->name = $employee->name;
         $this->email = $employee->email;
         $this->address = $employee->address;

--- a/resources/views/livewire/admins/employees.blade.php
+++ b/resources/views/livewire/admins/employees.blade.php
@@ -39,10 +39,9 @@
                         @error('email')
                             <span class="text-red-500 text-danger text-xs">{{ $message }}</span>
                         @enderror
-
                         <div class="form-group">
                             <label for="phone">Phone</label>
-                            <input type="number" max="1000000000000" name="phone" wire:model.lazy="phone"
+                            <input type="text" max="1000000000000" name="phone" wire:model.lazy="phone"
                                 placeholder="Enter Employee Phone" class="form-control" required cols="30"
                                 rows="5"></textarea>
                         </div>


### PR DESCRIPTION
Issue number 44, done. Problem solve when you try to edit an employee and the phone field, do not fill itself.
@Japoivvb 
Evidence:
Before
![image](https://github.com/Stucom-Pelai/DAW2_M07_UF3_Eloquent-Hospital/assets/125380442/93147ac7-e17a-4ced-8bc7-d5a97f41fb54)
After
![image](https://github.com/Stucom-Pelai/DAW2_M07_UF3_Eloquent-Hospital/assets/125380442/eb024d38-f239-421c-bbf4-c5d684189c1b)
